### PR TITLE
Update to use encodeURIComponent for escaping URL and title

### DIFF
--- a/extension/bookmark.js
+++ b/extension/bookmark.js
@@ -19,7 +19,7 @@ chrome.commands.onCommand.addListener(function(command) {
                 // so that the tab isn't created before the response with the description
                 // is received
                 chrome.tabs.create({
-                                url: 'https://pinboard.in/add?url=' + encodeURI(tab.url) + '&title=' + encodeURI(tab.title) +
+                                url: 'https://pinboard.in/add?url=' + encodeURIComponent(tab.url) + '&title=' + encodeURIComponent(tab.title) +
                                 '&description=' + encodeURIComponent(description),
                                 index: tab.index,
                             });

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -4,7 +4,7 @@
 
   "name": "Pinboard Keyboard Shortcut",
   "description": "Bookmark the current page to Pinboard via a keyboard shortcut",
-  "version": "1.0",
+  "version": "1.0.1",
 
   "background": {
     "scripts": ["bookmark.js"],


### PR DESCRIPTION
this will correctly encode "&" and other characters in the page title and the URL when passing them to Pinboard.